### PR TITLE
Improve start instructions and scripts

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -68,7 +68,7 @@ The agent selection is done in 4 steps:
 ## Getting Started
 
 1. Follow the setup instructions in `README.md` to clone the repo, configure `.env` and `config.ini`, and start Docker services.
-2. Use `start_services.sh full` to run the backend and the React frontend, then access the app on `http://localhost:3000`.
+2. Use `docker compose --profile full up` to run the backend and the React frontend, then access the app on `http://localhost:3000`.
 3. For CLI usage, run `python3 cli.py` after installation.
 
 ## Suggested Next Steps for Newcomers

--- a/README.md
+++ b/README.md
@@ -249,37 +249,35 @@ Next step: [Start services and run AgenticSeek](#Start-services-and-Run)
 
 By default AgenticSeek is run fully in docker.
 
-Start required services. This will start all services from the docker-compose.yml, including:
+Start required services with Docker Compose. This will start all services from the `docker-compose.yml` file, including:
     - searxng
     - redis (required by searxng)
     - frontend
-    - backend (if using `full`)
+    - backend
 
 ```sh
-./start_services.sh full # MacOS
-start ./start_services.cmd full # Window
+docker compose --profile full up
 ```
 
 **Warning:** This step will download and load all Docker images, which may take up to 30 minutes. After starting the services, please wait until the backend service is fully running (you should see **backend: "GET /health HTTP/1.1" 200 OK** in the log) before sending any messages. The backend services might take 5 minute to start on first run.
 
 Go to `http://localhost:3000/` and you should see the web interface.
 
-*Troubleshooting service start:* If these scripts fail, ensure Docker Engine is running and Docker Compose (V2, `docker compose`) is correctly installed. Check the output in the terminal for error messages. See [FAQ: Help! I get an error when running AgenticSeek or its scripts.](#faq-troubleshooting)
+*Troubleshooting service start:* If the compose command fails, ensure Docker Engine is running and Docker Compose (V2, `docker compose`) is correctly installed. Check the output in the terminal for error messages. See [FAQ: Help! I get an error when running AgenticSeek or its scripts.](#faq-troubleshooting)
 
 **Optional:** Run on host (CLI mode):
 
-To run with CLI interface you would have to install package on host:
+Install the required Python packages on your machine:
 
 ```sh
 ./install.sh
-./install.bat # windows
+./install.bat # Windows
 ```
 
-Start services:
+Start the services locally (backend will run on your host):
 
 ```sh
-./start_services.sh # MacOS
-start ./start_services.cmd # Window
+docker compose --profile core up
 ```
 
 Use the CLI: `python3 cli.py`
@@ -289,7 +287,7 @@ Use the CLI: `python3 cli.py`
 
 ## Usage
 
-Make sure the services are up and running with `./start_services.sh full` and go to `localhost:3000` for web interface.
+Make sure the services are up and running with `docker compose --profile full up` and go to `localhost:3000` for the web interface.
 
 You can also use speech to text by setting `listen = True` in the config. Only for CLI mode.
 

--- a/sources/tools/searxSearch.py
+++ b/sources/tools/searxSearch.py
@@ -95,7 +95,7 @@ class searxSearch(Tools):
                 return "No search results, web search failed."
             return "\n\n".join(results)  # Return results as a single string, separated by newlines
         except requests.exceptions.RequestException as e:
-            raise Exception("\nSearxng search failed. did you run start_services.sh? is docker still running?") from e
+            raise Exception("\nSearxng search failed. Did you run 'docker compose --profile full up'? Is Docker still running?") from e
 
     def execution_failure_check(self, output: str) -> bool:
         """

--- a/start_services.sh
+++ b/start_services.sh
@@ -10,6 +10,8 @@ if [ -z "$WORK_DIR" ]; then
     exit 1
 fi
 
+echo "If you intend to run AgenticSeek directly on your host (CLI mode) make sure to run ./install.sh first to install dependencies."
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
     dir_size_bytes=$(du -s -b "$WORK_DIR" 2>/dev/null | awk '{print $1}')
 else
@@ -28,7 +30,7 @@ fi
 if [ "$1" = "full" ]; then
     echo "Starting full deployment with backend and all services..."
 else
-    echo "Starting core deployment with frontend and search services only... use ./start_services.sh full to start backend as well"
+    echo "Starting core deployment with frontend and search services only... use 'docker compose --profile full up' to start the backend as well"
 fi
 
 if ! command_exists docker; then
@@ -63,18 +65,16 @@ else
     echo "Docker daemon is running."
 fi
 
-# Check if Docker Compose is installed
-if ! command_exists docker-compose && ! docker compose version >/dev/null 2>&1; then
-    echo "Error: Docker Compose is not installed. Please install it first."
-    echo "On Ubuntu: sudo apt install docker-compose"
-    echo "Or via pip: pip install docker-compose"
-    exit 1
-fi
-
-if command_exists docker-compose; then
-    COMPOSE_CMD="docker-compose"
-else
+# Check if Docker Compose is installed (prefer V2 'docker compose')
+if docker compose version >/dev/null 2>&1; then
     COMPOSE_CMD="docker compose"
+elif command_exists docker-compose; then
+    COMPOSE_CMD="docker-compose"
+    echo "Warning: using legacy docker-compose. Consider installing Docker Compose V2 (docker compose)."
+else
+    echo "Error: Docker Compose is not installed. Please install Docker Compose V2."
+    echo "On Ubuntu: sudo apt-get install docker-compose-plugin"
+    exit 1
 fi
 
 # Check if docker-compose.yml exists


### PR DESCRIPTION
## Summary
- prefer Docker Compose V2 in `start_services.sh`
- mention host installation in `start_services.sh`
- update README to use `docker compose` instead of `start_services.sh`
- update code overview docs
- clarify searxSearch failure message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685029ae62b88329b1ed6a126cccf5b2

## Summary by Sourcery

Improve service startup workflow by switching to Docker Compose V2, clarifying host installation steps, and updating related documentation and error messages.

Bug Fixes:
- Adjust searxSearch exception message to reference the new compose command

Enhancements:
- Prefer Docker Compose V2 in start_services.sh with legacy fallback and warning
- Add reminder to install dependencies before running CLI mode on the host
- Clarify searxSearch failure message to reference `docker compose --profile full up`

Documentation:
- Update README and CODEBASE_OVERVIEW to use `docker compose` commands and profiles instead of start_services scripts
- Revise optional CLI mode instructions to highlight dependency installation and local service startup